### PR TITLE
Add Goreleaser for release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,36 @@
+project_name: utils
+before:
+  hooks:
+    - make test
+    - make lint
+release:
+  github:
+    owner: kubermatic
+    name: utils
+  prerelease: true
+builds:
+  - id: build-testjsonformat
+    binary: testjsonformat
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - amd64
+      - "386"
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    main: cmd/testjsonformat/main.go
+archives:
+  - id: kubecarrier
+    builds:
+      - kubecarrier
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+    format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+checksum:
+  name_template: "{{ .ProjectName }}_checksums.txt"
+  algorithm: sha256

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,9 +23,9 @@ builds:
       - GO111MODULE=on
     main: cmd/testjsonformat/main.go
 archives:
-  - id: kubecarrier
+  - id: utils
     builds:
-      - kubecarrier
+      - build-testjsonformat
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
     format: tar.gz
     format_overrides:

--- a/Makefile
+++ b/Makefile
@@ -46,3 +46,7 @@ tidy:
 
 install-git-hooks:
 	pre-commit install
+
+release:
+	goreleaser release --rm-dist
+.PHONY: release


### PR DESCRIPTION
fixes #7 
Here is a pre-release created by using `make release`: https://github.com/kubermatic/utils/releases/tag/v0.1.0-DEBUG, this will be removed once this PR is merged.